### PR TITLE
Displayed Query + Timestamp + "\n"

### DIFF
--- a/extension/commands.js
+++ b/extension/commands.js
@@ -7,7 +7,8 @@ function runFile ( { conn, file, channel, onEnd }) {
 
     const args = [
         "-d", conn,
-        "-f", file
+        "-f", file,
+        "-e"
     ];
 
     const psql = 'psql'
@@ -30,6 +31,9 @@ function runFile ( { conn, file, channel, onEnd }) {
 
     channel.show( vscode.ViewColumn.Two )
     bgtask.stdout.setEncoding('utf8')
+    var dt = new Date();
+    var utcDate = dt.toUTCString();
+    channel.appendLine(`---------  ${utcDate}  ---------`)
 
     const toChannel = data => {
         const str = data.toString(), lines = str.match( /[^\r\n]+/g )
@@ -42,7 +46,7 @@ function runFile ( { conn, file, channel, onEnd }) {
     onEnd = onEnd ? onEnd : ()=>{}
 
     bgtask.stdout.on( 'end', () => {
-        channel.appendLine( `${psql} end.` )
+        channel.appendLine( `${psql} end.\n` )
         onEnd()
     })
 


### PR DESCRIPTION
Hi,

I modified the code for below features (which helps me lot)
- Showing which query was executed.
- Timestamp when it was executed.
- A line break in between multiple requests.

Hope this would be helpful to you. You can ignore it as it is your repo. Here is a sample output.
```
--------  Sun, 25 Feb 2018 02:56:49 GMT  -----------
SELECT COUNT(*) FROM test;
 count 
-------
   691
(1 row)
psql end.

--------  Sun, 25 Feb 2018 02:57:35 GMT  -----------
SELECT COUNT(*) FROM test2;
 count 
-------
     99
(1 row)
psql end.
```